### PR TITLE
:oncoming_automobile: enable auto_assign for PRs

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,17 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers: 
+  - chicks-net
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+skipKeywords:
+  - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0


### PR DESCRIPTION
# before

Auto assign doesn't work on personal repos since teams are not available.

# did

Added config for https://github.com/kentaro-m/auto-assign/

# verify

Will need to wait for the next dependabot PR.  (Which probably won't take long.)